### PR TITLE
Delay rendering until translations are loaded

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -19,7 +19,7 @@ export default function HomePage() {
   const searchParams = useSearchParams()
   const router = useRouter()
   const { toast } = useToast()
-  const { t } = useLanguage()
+  const { t, isLoading: isLangLoading } = useLanguage()
 
   const [currentGame, setCurrentGame] = useState<Game | null>(null)
   const [currentSeed, setCurrentSeed] = useState<number | null>(null)
@@ -237,6 +237,10 @@ export default function HomePage() {
 
   const handleRetry = () => {
     setError(null)
+  }
+
+  if (isLangLoading) {
+    return null
   }
 
   return (

--- a/components/CookieConsent.tsx
+++ b/components/CookieConsent.tsx
@@ -10,13 +10,17 @@ import { useLanguage } from "@/hooks/useLanguage"
 
 export function CookieConsent() {
   const [showConsent, setShowConsent] = useState(false)
-  const { t } = useLanguage()
+  const { t, isLoading } = useLanguage()
 
   useEffect(() => {
     // Show consent banner if not already accepted
     const hasConsent = hasConsentCookie()
     setShowConsent(!hasConsent)
   }, [])
+
+  if (isLoading) {
+    return null
+  }
 
   const handleAccept = () => {
     setConsentCookie()

--- a/components/Navigation.tsx
+++ b/components/Navigation.tsx
@@ -7,7 +7,11 @@ import { useLanguage } from "@/hooks/useLanguage"
 import { Gamepad2 } from "lucide-react"
 
 export function Navigation() {
-  const { t } = useLanguage()
+  const { t, isLoading } = useLanguage()
+
+  if (isLoading) {
+    return null
+  }
 
   return (
     <motion.nav

--- a/hooks/useLanguage.ts
+++ b/hooks/useLanguage.ts
@@ -18,26 +18,6 @@ export function useLanguage(): UseLanguageReturn {
   const [language, setLanguageState] = useState<Language>(DEFAULT_LANGUAGE)
   const [isLoading, setIsLoading] = useState(true)
 
-  // Initialize language from cookie or browser
-  useEffect(() => {
-    const cookieLang = getCookie("lang") as Language
-    const initialLang = cookieLang || detectBrowserLanguage()
-    setLanguageState(initialLang)
-
-    if (!cookieLang) {
-      setCookie("lang", initialLang, { maxAge: 365 * 24 * 60 * 60 }) // 1 year
-    }
-
-    setIsLoading(false)
-  }, [])
-
-  const setLanguage = useCallback((lang: Language) => {
-    setLanguageState(lang)
-    setCookie("lang", lang, { maxAge: 365 * 24 * 60 * 60 })
-    // Reload page to apply server-side language changes
-    window.location.reload()
-  }, [])
-
   const loadTranslations = useCallback(async (lang: Language, namespace = "common"): Promise<TranslationKeys> => {
     const cacheKey = `${lang}-${namespace}`
 
@@ -64,6 +44,26 @@ export function useLanguage(): UseLanguageReturn {
 
       return {}
     }
+  }, [])
+
+  // Initialize language from cookie or browser
+  useEffect(() => {
+    const cookieLang = getCookie("lang") as Language
+    const initialLang = cookieLang || detectBrowserLanguage()
+    setLanguageState(initialLang)
+
+    if (!cookieLang) {
+      setCookie("lang", initialLang, { maxAge: 365 * 24 * 60 * 60 }) // 1 year
+    }
+
+    loadTranslations(initialLang).finally(() => setIsLoading(false))
+  }, [loadTranslations])
+
+  const setLanguage = useCallback((lang: Language) => {
+    setLanguageState(lang)
+    setCookie("lang", lang, { maxAge: 365 * 24 * 60 * 60 })
+    // Reload page to apply server-side language changes
+    window.location.reload()
   }, [])
 
   const t = useCallback(


### PR DESCRIPTION
## Summary
- Load translation files before clearing language loading state in `useLanguage`
- Prevent rendering of pages and navigation until translations are ready
- Hide cookie consent banner until translation data is available

## Testing
- `pnpm lint` *(fails: requires interactive ESLint setup)*
- `pnpm build` *(fails: build process interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_689e896356d8832db7ddcd3a680f90f9