### PR TITLE
feat: add header controls and store links

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -5,6 +5,7 @@ import { GeistMono } from "geist/font/mono"
 import { Navigation } from "@/components/Navigation"
 import { CookieConsent } from "@/components/CookieConsent"
 import { Toaster } from "@/components/ui/toaster"
+import { cookies } from "next/headers"
 import "./globals.css"
 
 export const metadata: Metadata = {
@@ -33,16 +34,14 @@ export default function RootLayout({
 }: Readonly<{
   children: React.ReactNode
 }>) {
+  const cookieStore = cookies()
+  const theme = cookieStore.get("theme")?.value === "light" ? "light" : "dark"
+  const lang = cookieStore.get("lang")?.value || "de"
+
   return (
-    <html lang="de" className="dark" dir="ltr">
+    <html lang={lang} className={theme} dir="ltr">
       <head>
-        <style>{`
-html {
-  font-family: ${GeistSans.style.fontFamily};
-  --font-sans: ${GeistSans.variable};
-  --font-mono: ${GeistMono.variable};
-}
-        `}</style>
+        <style>{`html { font-family: ${GeistSans.style.fontFamily}; --font-sans: ${GeistSans.variable}; --font-mono: ${GeistMono.variable}; }`}</style>
         <link rel="alternate" hrefLang="de" href="/" />
       </head>
       <body className="min-h-screen bg-background font-sans antialiased">

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -14,6 +14,7 @@ import { useToast } from "@/hooks/use-toast"
 import { useLanguage } from "@/hooks/useLanguage"
 import { decodeUrlState, createPermalink } from "@/lib/url-state"
 import { generateSeed } from "@/lib/random"
+import { buildStoreLink } from "@/lib/storeLinks"
 
 export default function HomePage() {
   const searchParams = useSearchParams()
@@ -201,34 +202,9 @@ export default function HomePage() {
   }
 
   const handleOpenStore = (game: Game) => {
-    if (game.stores && game.stores.length > 0) {
-      const entry = game.stores[0]
-      const store = entry.store
-      const title = encodeURIComponent(game.name)
-      let storeUrl = entry.url || ""
-
-      switch (store.name.toLowerCase()) {
-        case "steam":
-          storeUrl = entry.url || `https://store.steampowered.com/search/?term=${title}`
-          break
-        case "epic games store":
-          storeUrl = entry.url || `https://store.epicgames.com/store/en-US/search?q=${title}`
-          break
-        case "ea app":
-        case "origin":
-          storeUrl =
-            entry.url ||
-            (store.slug ? `https://www.ea.com/games/library/${store.slug}` : `https://www.ea.com/search?q=${title}`)
-          break
-        case "ubisoft connect":
-          storeUrl = entry.url || `https://store.ubisoft.com/search?q=${title}`
-          break
-        default:
-          storeUrl = entry.url || `https://www.google.com/search?q=${title}`
-      }
-
-      window.open(storeUrl, "_blank", "noopener,noreferrer")
-    }
+    const preferred = filters.stores[0] as any
+    const url = buildStoreLink(game, preferred)
+    window.open(url, "_blank", "noopener,noreferrer")
   }
 
   const handleSelectFromHistory = (game: Game) => {

--- a/components/GameCard.tsx
+++ b/components/GameCard.tsx
@@ -43,7 +43,9 @@ export function GameCard({ game, seed, strategy, onReroll, onAlternative, onShar
   const [imageLoaded, setImageLoaded] = useState(false)
 
   const formatPrice = (price?: number, currency = "EUR") => {
-    if (!price || price === 0) return t("game.price.free")
+    if (price === undefined || price === null) {
+      return t("game.price.unavailable")
+    }
 
     const locale =
       language === "en"
@@ -110,10 +112,12 @@ export function GameCard({ game, seed, strategy, onReroll, onAlternative, onShar
             transition={{ duration: 0.6, ease: "easeOut" }}
           >
             <Image
-              src={game.background_image || "/placeholder.svg?height=400&width=600&query=gaming"}
+              src={game.background_image || "/placeholder.jpg"}
               alt={game.name}
               fill
               className="object-cover group-hover:scale-105 transition-transform duration-700"
+              placeholder="blur"
+              blurDataURL="/placeholder.jpg"
               onLoad={() => setImageLoaded(true)}
             />
           </motion.div>
@@ -257,15 +261,12 @@ export function GameCard({ game, seed, strategy, onReroll, onAlternative, onShar
             className="flex items-center justify-between"
             initial={{ opacity: 0, y: 10 }}
             animate={{ opacity: 1, y: 0 }}
-            transition={{ delay: 1.1, duration: 0.4 }}
+          transition={{ delay: 1.1, duration: 0.4 }}
           >
             <motion.div whileHover={{ scale: 1.02 }} transition={{ type: "spring", stiffness: 400 }}>
-              <p className="text-lg font-semibold">{t("game.price.free")}</p>
-              {game.price && game.price > 0 && (
-                <p className="text-xs text-muted-foreground">
-                  {t("game.price.actual").replace("{{price}}", formatPrice(game.price, game.currency))}
-                </p>
-              )}
+              <p className="text-lg font-semibold">
+                {formatPrice(game.price, game.currency)}
+              </p>
             </motion.div>
 
             <div className="flex gap-2">

--- a/components/Navigation.tsx
+++ b/components/Navigation.tsx
@@ -4,6 +4,8 @@ import { motion } from "framer-motion"
 // Language switcher and theme toggle removed – site is German-only and dark mode only
 import { useLanguage } from "@/hooks/useLanguage"
 import { Gamepad2 } from "lucide-react"
+import { ThemeToggle } from "./ThemeToggle"
+import { LanguageSwitcher } from "./LanguageSwitcher"
 
 export function Navigation() {
   const { t, isLoading } = useLanguage()
@@ -50,7 +52,8 @@ export function Navigation() {
             animate={{ opacity: 1, x: 0 }}
             transition={{ delay: 0.3, duration: 0.5 }}
           >
-            {/* Theme and language controls removed */}
+            <LanguageSwitcher />
+            <ThemeToggle />
           </motion.div>
         </div>
       </div>

--- a/components/ThemeToggle.tsx
+++ b/components/ThemeToggle.tsx
@@ -4,21 +4,18 @@ import { useState, useEffect } from "react"
 import { motion } from "framer-motion"
 import { Button } from "@/components/ui/button"
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip"
-import { Sun, Moon, Monitor } from "lucide-react"
+import { Sun, Moon } from "lucide-react"
 import { useSettings } from "@/hooks/useSettings"
 import { useLanguage } from "@/hooks/useLanguage"
-import type { Settings } from "@/types/language"
 
 const themeIcons = {
   light: Sun,
   dark: Moon,
-  system: Monitor,
 }
 
 const themeLabels = {
   light: "settings.themes.light",
   dark: "settings.themes.dark",
-  system: "settings.themes.system",
 }
 
 export function ThemeToggle() {
@@ -31,9 +28,7 @@ export function ThemeToggle() {
   }, [])
 
   const handleThemeChange = async () => {
-    const themes: Settings["theme"][] = ["light", "dark", "system"]
-    const currentIndex = themes.indexOf(settings.theme)
-    const nextTheme = themes[(currentIndex + 1) % themes.length]
+    const nextTheme = settings.theme === "light" ? "dark" : "light"
 
     try {
       await setTheme(nextTheme)

--- a/components/ui/sonner.tsx
+++ b/components/ui/sonner.tsx
@@ -6,7 +6,7 @@ import { Toaster as Sonner } from "sonner"
 type ToasterProps = React.ComponentProps<typeof Sonner>
 
 const Toaster = ({ ...props }: ToasterProps) => {
-  const { theme = "system" } = useTheme()
+  const { theme = "dark" } = useTheme()
 
   return (
     <Sonner

--- a/config/theme.config.ts
+++ b/config/theme.config.ts
@@ -1,6 +1,6 @@
 export const THEME_CONFIG = {
   // Available Themes
-  themes: ["light", "dark", "system"] as const,
+  themes: ["light", "dark"] as const,
 
   // Default Theme
   defaultTheme: "dark" as const,

--- a/hooks/useSettings.ts
+++ b/hooks/useSettings.ts
@@ -8,7 +8,7 @@ import { changeThemeAction, saveFiltersAction } from "@/lib/actions/settings"
 
 const DEFAULT_SETTINGS: Settings = {
   language: DEFAULT_LANGUAGE,
-  theme: "system",
+  theme: "dark",
   filters: {},
 }
 
@@ -40,7 +40,7 @@ export function useSettings(): UseSettingsReturn {
       }
 
       const lang = (getCookie("lang") as Language) || DEFAULT_LANGUAGE
-      const theme = (getCookie("theme") as Settings["theme"]) || "system"
+      const theme = (getCookie("theme") as Settings["theme"]) || "dark"
       const filtersJson = getCookie("filters")
 
       let filters = {}

--- a/lib/cookies.ts
+++ b/lib/cookies.ts
@@ -126,7 +126,7 @@ export function setLanguageCookie(language: string): void {
 }
 
 export function getThemeCookie(): string {
-  return getCookie("theme") || "system"
+  return getCookie("theme") || "dark"
 }
 
 export function setThemeCookie(theme: string): void {

--- a/lib/languages.ts
+++ b/lib/languages.ts
@@ -3,9 +3,33 @@ import type { Language, LanguageConfig } from "@/types/language"
 export const SUPPORTED_LANGUAGES: LanguageConfig[] = [
   {
     code: "de",
-    name: "Deutsch",
+    name: "German",
     nativeName: "Deutsch",
     flag: "🇩🇪",
+  },
+  {
+    code: "en",
+    name: "English",
+    nativeName: "English",
+    flag: "🇬🇧",
+  },
+  {
+    code: "fr",
+    name: "French",
+    nativeName: "Français",
+    flag: "🇫🇷",
+  },
+  {
+    code: "es",
+    name: "Spanish",
+    nativeName: "Español",
+    flag: "🇪🇸",
+  },
+  {
+    code: "tr",
+    name: "Turkish",
+    nativeName: "Türkçe",
+    flag: "🇹🇷",
   },
 ]
 

--- a/lib/server-cookies.ts
+++ b/lib/server-cookies.ts
@@ -7,14 +7,14 @@ export function getServerLanguage() {
 
 export function getServerTheme() {
   console.warn("Server-side cookie access disabled in preview environment")
-  return "system"
+  return "dark"
 }
 
 export function getServerSettings() {
   console.warn("Server-side cookie access disabled in preview environment")
   return {
     language: "de" as const,
-    theme: "system" as const,
+    theme: "dark" as const,
     filters: {},
   }
 }

--- a/lib/storeLinks.ts
+++ b/lib/storeLinks.ts
@@ -1,0 +1,57 @@
+import type { Game } from "@/components/GameCard"
+
+export type StoreSlug = "steam" | "epic" | "ea" | "ubisoft"
+
+function slugifyTitle(title: string): string {
+  return title
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+}
+
+export function buildStoreLink(game: Game, preferred?: StoreSlug): string {
+  const stores = game.stores || []
+  const title = encodeURIComponent(game.name)
+  const slugTitle = slugifyTitle(game.name)
+
+  const findStore = (slug: StoreSlug) =>
+    stores.find((s) =>
+      s.store.slug?.toLowerCase() === slug || s.store.name.toLowerCase().includes(slug),
+    )
+
+  const steamFallback = `https://store.steampowered.com/search/?term=${title}`
+
+  const tryBuild = (entry: any, slug: StoreSlug): string | null => {
+    if (!entry) return null
+    switch (slug) {
+      case "steam": {
+        const appIdMatch = entry.url?.match(/app\/(\d+)/)
+        if (appIdMatch) {
+          return `https://store.steampowered.com/app/${appIdMatch[1]}/${slugTitle}/`
+        }
+        return steamFallback
+      }
+      case "epic":
+        return entry.url || `https://store.epicgames.com/en-US/browse?q=${title}`
+      case "ea":
+        return entry.url || `https://www.ea.com/search?q=${title}`
+      case "ubisoft":
+        return entry.url || `https://store.ubisoft.com/search?q=${title}`
+      default:
+        return null
+    }
+  }
+
+  if (preferred) {
+    const preferredEntry = findStore(preferred)
+    const link = tryBuild(preferredEntry, preferred)
+    if (link) return link
+  }
+
+  const steamEntry = findStore("steam")
+  const link = tryBuild(steamEntry, "steam")
+  if (link) return link
+
+  // final fallback
+  return steamFallback
+}

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -7,7 +7,14 @@ const nextConfig = {
     ignoreBuildErrors: true,
   },
   images: {
-    unoptimized: true,
+    remotePatterns: [
+      { protocol: "https", hostname: "media.rawg.io" },
+      { protocol: "https", hostname: "steamcdn-a.akamaihd.net" },
+      { protocol: "https", hostname: "cdn.akamai.steamstatic.com" },
+      { protocol: "https", hostname: "store.ubisoft.com" },
+      { protocol: "https", hostname: "static-assets-prod.epicgames.com" },
+      { protocol: "https", hostname: "images.igdb.com" },
+    ],
   },
 }
 

--- a/public/languages/de/common.json
+++ b/public/languages/de/common.json
@@ -41,11 +41,12 @@
     }
   },
   "game": {
-    "price": {
-      "free": "Kostenlos",
-      "freeToPlay": "Free-to-Play",
-      "actual": "Tatsächlicher Preis: {{price}}"
-    },
+      "price": {
+        "free": "Kostenlos",
+        "freeToPlay": "Free-to-Play",
+        "actual": "Tatsächlicher Preis: {{price}}",
+        "unavailable": "Preis nicht verfügbar"
+      },
     "rating": "Bewertung",
     "metacritic": "Metacritic",
     "released": "Veröffentlicht",

--- a/public/languages/en/common.json
+++ b/public/languages/en/common.json
@@ -39,7 +39,8 @@
   "game": {
     "price": {
       "free": "Free",
-      "freeToPlay": "Free-to-Play"
+      "freeToPlay": "Free-to-Play",
+      "unavailable": "Price unavailable"
     },
     "rating": "Rating",
     "metacritic": "Metacritic",

--- a/public/languages/es/common.json
+++ b/public/languages/es/common.json
@@ -39,7 +39,8 @@
   "game": {
     "price": {
       "free": "Gratis",
-      "freeToPlay": "Free-to-Play"
+      "freeToPlay": "Free-to-Play",
+      "unavailable": "Precio no disponible"
     },
     "rating": "Valoración",
     "metacritic": "Metacritic",

--- a/public/languages/fr/common.json
+++ b/public/languages/fr/common.json
@@ -39,7 +39,8 @@
   "game": {
     "price": {
       "free": "Gratuit",
-      "freeToPlay": "Free-to-Play"
+      "freeToPlay": "Free-to-Play",
+      "unavailable": "Prix indisponible"
     },
     "rating": "Note",
     "metacritic": "Metacritic",

--- a/public/languages/tr/common.json
+++ b/public/languages/tr/common.json
@@ -39,7 +39,8 @@
   "game": {
     "price": {
       "free": "Ücretsiz",
-      "freeToPlay": "Free-to-Play"
+      "freeToPlay": "Free-to-Play",
+      "unavailable": "Fiyat mevcut değil"
     },
     "rating": "Puan",
     "metacritic": "Metacritic",

--- a/types/language.ts
+++ b/types/language.ts
@@ -1,4 +1,4 @@
-export type Language = "de"
+export type Language = "de" | "en" | "fr" | "es" | "tr"
 
 export interface LanguageConfig {
   code: Language
@@ -13,7 +13,7 @@ export interface TranslationKeys {
 
 export interface Settings {
   language: Language
-  theme: "light" | "dark" | "system"
+  theme: "light" | "dark"
   filters: {
     platform?: string
     store?: string


### PR DESCRIPTION
## Summary
- add language switcher and theme toggle to site header with cookie persistence
- display real game prices and robust store links with fallbacks
- configure image domains and language/theme cookies for SSR

## Testing
- `npm run lint` *(fails: prompts for ESLint config)*

------
https://chatgpt.com/codex/tasks/task_e_689f52782d90832da7e169043070dfc0