### PR TITLE
Handle missing RAWG API key gracefully

### DIFF
--- a/app/api/games/route.ts
+++ b/app/api/games/route.ts
@@ -93,22 +93,28 @@ async function searchGamesWithFallbacks(params: any): Promise<{ games: any[]; fa
   let games: any[] = []
   let fallback = false
 
-  try {
-    // Primary: RAWG API
-    const response = await searchGames({
-      ...params,
-      page_size: "100", // Get more results for better filtering
-      ordering: "-rating,-metacritic", // Prioritize highly rated games
-    })
-    games = response.results || []
-  } catch (error) {
-    const message = error instanceof Error ? error.message : String(error)
-    if (message.includes("401")) {
-      console.error("RAWG API unauthorized - using fallback dataset")
-      games = [...fallbackGames]
-      fallback = true
-    } else {
-      console.error("RAWG API failed, trying fallbacks:", error)
+  if (!process.env.RAWG_KEY) {
+    console.error("RAWG API key missing - using fallback dataset")
+    games = [...fallbackGames]
+    fallback = true
+  } else {
+    try {
+      // Primary: RAWG API
+      const response = await searchGames({
+        ...params,
+        page_size: "100", // Get more results for better filtering
+        ordering: "-rating,-metacritic", // Prioritize highly rated games
+      })
+      games = response.results || []
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error)
+      if (message.includes("401")) {
+        console.error("RAWG API unauthorized - using fallback dataset")
+        games = [...fallbackGames]
+        fallback = true
+      } else {
+        console.error("RAWG API failed, trying fallbacks:", error)
+      }
     }
   }
 

--- a/lib/api/rawg.ts
+++ b/lib/api/rawg.ts
@@ -20,6 +20,7 @@ export interface RAWGResponse {
 import Bottleneck from "bottleneck"
 
 const RAWG_API_KEY = process.env.RAWG_KEY || ""
+const API_KEY_MISSING_ERROR = "RAWG API key is not configured"
 const BASE_URL = "https://api.rawg.io/api"
 
 const limiter = new Bottleneck({
@@ -37,6 +38,10 @@ export async function searchGames(params: {
   ordering?: string
   search?: string
 }): Promise<RAWGResponse> {
+  if (!RAWG_API_KEY) {
+    throw new Error(API_KEY_MISSING_ERROR)
+  }
+
   const searchParams = new URLSearchParams({
     key: RAWG_API_KEY,
     page_size: "40",
@@ -58,6 +63,10 @@ export async function searchGames(params: {
 }
 
 export async function getGameDetails(id: number): Promise<RAWGGame> {
+  if (!RAWG_API_KEY) {
+    throw new Error(API_KEY_MISSING_ERROR)
+  }
+
   try {
     const response = await limiter.schedule(() => fetch(`${BASE_URL}/games/${id}?key=${RAWG_API_KEY}`))
 


### PR DESCRIPTION
## Summary
- Avoid RAWG API requests when `RAWG_KEY` is missing
- Provide clearer errors for game search and detail requests

## Testing
- `pnpm lint` *(fails: How would you like to configure ESLint?)*
- `pnpm build` *(fails: interrupted during collecting page data)*

------
https://chatgpt.com/codex/tasks/task_e_689f698523fc832dad9a38589f975efc