### PR TITLE
refactor: use transitions for language and theme

### DIFF
--- a/components/ThemeToggle.tsx
+++ b/components/ThemeToggle.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useState, useEffect } from "react"
+import { useState, useEffect, useTransition } from "react"
 import { motion } from "framer-motion"
 import { Button } from "@/components/ui/button"
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip"
@@ -22,19 +22,22 @@ export function ThemeToggle() {
   const { settings, setTheme, isLoading } = useSettings()
   const { t } = useLanguage()
   const [mounted, setMounted] = useState(false)
+  const [isPending, startTransition] = useTransition()
 
   useEffect(() => {
     setMounted(true)
   }, [])
 
-  const handleThemeChange = async () => {
+  const handleThemeChange = () => {
     const nextTheme = settings.theme === "light" ? "dark" : "light"
 
-    try {
-      await setTheme(nextTheme)
-    } catch (error) {
-      console.error("Failed to change theme:", error)
-    }
+    startTransition(async () => {
+      try {
+        await setTheme(nextTheme)
+      } catch (error) {
+        console.error("Failed to change theme:", error)
+      }
+    })
   }
 
   if (!mounted || isLoading) {
@@ -52,6 +55,7 @@ export function ThemeToggle() {
             variant="outline"
             size="sm"
             onClick={handleThemeChange}
+            disabled={isPending}
             className="h-9 w-9 p-0 bg-background/50 backdrop-blur-sm border-border/50 hover:bg-background/80"
           >
             <motion.div


### PR DESCRIPTION
## Summary
- use React transitions and server actions in LanguageSwitcher to update cookies and refresh layout
- wrap theme changes in a transition for non-blocking UI
- simplify language hook to load translations without full page reload

## Testing
- `pnpm lint` *(fails: How would you like to configure ESLint?)*

------
https://chatgpt.com/codex/tasks/task_e_689fc349530c832d914b0e3a9536389d