### PR TITLE
refactor games api to always fetch live and return list

### DIFF
--- a/app/api/games/route.ts
+++ b/app/api/games/route.ts
@@ -1,10 +1,8 @@
 import { type NextRequest, NextResponse } from "next/server"
-import { searchGames } from "@/lib/api/rawg"
-import { selectGameWithStrategy, generateAlternatives, decodeSeed, generateSeed } from "@/lib/random"
+import { searchGames, getGameStores } from "@/lib/api/rawg"
 import { LRUCache } from "lru-cache"
 import { getRawgPlatformIds, getRawgStoreIds, getRawgGenreIds } from "@/lib/mapping"
 import { isPriceInRange } from "@/lib/price"
-import { matchGamesToPreferences } from "@/lib/game-matcher"
 import fallbackGames from "@/data/games-fallback.json"
 
 const memoryCache = new LRUCache<string, { games: any[]; fallback: boolean }>({
@@ -12,42 +10,37 @@ const memoryCache = new LRUCache<string, { games: any[]; fallback: boolean }>({
   ttl: 1000 * 60 * 15,
   allowStale: true,
 })
+
 let Redis: any
 if (process.env.REDIS_URL) {
   // eslint-disable-next-line @typescript-eslint/no-var-requires
   Redis = require("ioredis")
 }
 const redis = process.env.REDIS_URL && Redis ? new Redis(process.env.REDIS_URL) : null
-const inFlight = new Map<string, Promise<{ games: any[]; fallback: boolean }>>()
 
 function keyFromObj(searchParams: URLSearchParams) {
   const obj = Object.fromEntries([...searchParams.entries()].sort()) as Record<string, any>
-  delete obj.seed
-  delete obj.strategy
   return JSON.stringify(obj)
 }
 
-async function fetchAndCache(key: string, params: any) {
-  let promise = inFlight.get(key)
-  if (!promise) {
-    promise = searchGamesWithFallbacks(params)
-      .then((res) => {
-        memoryCache.set(key, res)
-        if (redis) {
-          redis.set(key, JSON.stringify(res), "EX", 900).catch(() => {})
-        }
-        return res
-      })
-      .finally(() => {
-        inFlight.delete(key)
-      })
-    inFlight.set(key, promise)
+async function fetchRawg(params: any) {
+  const response = await searchGames({
+    ...params,
+    page_size: 40,
+    ordering: "-rating,-metacritic",
+    page: 1,
+  })
+  let games = response.results || []
+  if (games.length < 10) {
+    const second = await searchGames({
+      ...params,
+      page_size: 40,
+      ordering: "-rating,-metacritic",
+      page: 2,
+    })
+    games = [...games, ...(second.results || [])]
   }
-  return promise
-}
-
-function revalidate(key: string, params: any) {
-  fetchAndCache(key, params).catch((err) => console.error("revalidate failed", err))
+  return games
 }
 
 function filterGames(
@@ -63,7 +56,6 @@ function filterGames(
   },
 ) {
   return games.filter((game) => {
-    // Platform filtering
     if (filters.platforms && filters.platforms.length > 0) {
       const gamePlatforms = game.platforms?.map((p: any) => p.platform.name.toLowerCase()) || []
       const hasMatchingPlatform = filters.platforms.some((platform) =>
@@ -75,29 +67,22 @@ function filterGames(
       if (!hasMatchingPlatform) return false
     }
 
-    // Store filtering
     if (filters.stores && filters.stores.length > 0) {
       const gameStores = game.stores?.map((s: any) => s.store.name.toLowerCase()) || []
       const hasMatchingStore = filters.stores.some((store) =>
-        gameStores.some(
-          (gameStore) => gameStore.includes(store.toLowerCase()) || store.toLowerCase().includes(gameStore),
-        ),
+        gameStores.some((gameStore) => gameStore.includes(store.toLowerCase()) || store.toLowerCase().includes(gameStore)),
       )
       if (!hasMatchingStore) return false
     }
 
-    // Genre filtering
     if (filters.genres && filters.genres.length > 0) {
       const gameGenres = game.genres?.map((g: any) => g.name.toLowerCase()) || []
       const hasMatchingGenre = filters.genres.some((genre) =>
-        gameGenres.some(
-          (gameGenre) => gameGenre.includes(genre.toLowerCase()) || genre.toLowerCase().includes(gameGenre),
-        ),
+        gameGenres.some((gameGenre) => gameGenre.includes(genre.toLowerCase()) || genre.toLowerCase().includes(gameGenre)),
       )
       if (!hasMatchingGenre) return false
     }
 
-    // Price filtering
     if (filters.freeToPlay) {
       if (!game.free_to_play && game.price !== 0) return false
     } else if (filters.maxPrice !== undefined) {
@@ -106,12 +91,10 @@ function filterGames(
       }
     }
 
-    // Rating filtering
     if (filters.minRating && game.rating < filters.minRating) {
       return false
     }
 
-    // High-rated only filter
     if (filters.onlyHighRated && (game.rating < 4.0 || (game.metacritic && game.metacritic < 75))) {
       return false
     }
@@ -120,53 +103,30 @@ function filterGames(
   })
 }
 
-async function searchGamesWithFallbacks(params: any): Promise<{ games: any[]; fallback: boolean }> {
-  let games: any[] = []
-  let fallback = false
-
-  if (!process.env.RAWG_KEY) {
-    console.error("RAWG API key missing - using fallback dataset")
-    games = [...fallbackGames]
-    fallback = true
-  } else {
-    try {
-      // Primary: RAWG API
-      const response = await searchGames({
-        ...params,
-        page_size: "100", // Get more results for better filtering
-        ordering: "-rating,-metacritic", // Prioritize highly rated games
-      })
-      games = response.results || []
-    } catch (error) {
-      const message = error instanceof Error ? error.message : String(error)
-      if (message.includes("401")) {
-        console.error("RAWG API unauthorized - using fallback dataset")
-        games = [...fallbackGames]
-        fallback = true
-      } else {
-        console.error("RAWG API failed, trying fallbacks:", error)
+async function enrichSteamIds(games: any[]) {
+  await Promise.all(
+    games.map(async (g) => {
+      const steamStore = g.stores?.find((s: any) => s.store?.slug === "steam")
+      if (steamStore) {
+        const match = steamStore.url?.match(/\/app\/(\d+)/)
+        if (match) {
+          g.steamAppId = Number(match[1])
+        } else {
+          try {
+            const details = await getGameStores(g.id)
+            const steam = details.find((s: any) => s.store?.slug === "steam")
+            if (steam?.url) {
+              steamStore.url = steam.url
+              const m = steam.url.match(/\/app\/(\d+)/)
+              if (m) g.steamAppId = Number(m[1])
+            }
+          } catch {
+            // ignore
+          }
+        }
       }
-    }
-  }
-
-  // If RAWG returns few results, supplement with fallback data
-  if (!fallback && games.length < 10) {
-    console.log("Using fallback games due to insufficient results")
-    games = [...games, ...fallbackGames]
-  }
-
-  games = games.map((g) => ({
-    ...g,
-    steamAppId:
-      g.stores &&
-      (() => {
-        const url = g.stores.find((s: any) => s.store?.slug === "steam")?.url
-        const match = url?.match(/\/app\/(\d+)/)
-        return match ? Number(match[1]) : undefined
-      })(),
-  }))
-
-  return { games, fallback }
+    }),
+  )
 }
 
 export async function GET(req: NextRequest) {
@@ -177,66 +137,37 @@ export async function GET(req: NextRequest) {
   const maxPrice = searchParams.get("maxPrice")
   const freeToPlay = searchParams.get("freeToPlay") === "true"
   const onlyHighRated = searchParams.get("onlyHighRated") === "true"
-  const seedParam = searchParams.get("seed")
-  const strategy = searchParams.get("strategy") || "balanced"
-  const getAlternatives = searchParams.get("alternatives") === "true"
   const startYear = searchParams.get("startYear")
   const endYear = searchParams.get("endYear")
 
   const cacheKey = keyFromObj(searchParams)
-  let source: "hit" | "redis" | "miss" = "miss"
 
   try {
-    const seed = seedParam ? decodeSeed(seedParam) : generateSeed()
-
     const apiParams: any = {}
-    if (platforms.length > 0) {
-      apiParams.platforms = getRawgPlatformIds(platforms as any)
-    }
-    if (stores.length > 0) {
-      apiParams.stores = getRawgStoreIds(stores as any)
-    }
-    if (genres.length > 0) {
-      apiParams.genres = getRawgGenreIds(genres as any)
-    }
-    if (startYear && endYear) {
-      apiParams.dates = `${startYear}-01-01,${endYear}-12-31`
-    }
+    if (platforms.length > 0) apiParams.platforms = getRawgPlatformIds(platforms as any)
+    if (stores.length > 0) apiParams.stores = getRawgStoreIds(stores as any)
+    if (genres.length > 0) apiParams.genres = getRawgGenreIds(genres as any)
+    if (startYear && endYear) apiParams.dates = `${startYear}-01-01,${endYear}-12-31`
+    if (freeToPlay) apiParams.tags = "free-to-play"
 
-    let result = memoryCache.get(cacheKey)
-    if (result) {
-      source = "hit"
-      revalidate(cacheKey, apiParams)
-    } else if (redis) {
-      const redisValue = await redis.get(cacheKey)
-      if (redisValue) {
-        result = JSON.parse(redisValue)
-        source = "redis"
-        memoryCache.set(cacheKey, result)
-        revalidate(cacheKey, apiParams)
+    let storeFilterActive = true
+    let games = await fetchRawg(apiParams)
+    if (games.length < 10) {
+      games = [...games, ...fallbackGames]
+    }
+    if (games.length === 0 && stores.length > 0) {
+      const paramsNoStore = { ...apiParams }
+      delete paramsNoStore.stores
+      games = await fetchRawg(paramsNoStore)
+      if (games.length < 10) {
+        games = [...games, ...fallbackGames]
       }
+      storeFilterActive = false
     }
 
-    if (!result) {
-      result = await fetchAndCache(cacheKey, apiParams)
-    }
-
-    let gamesData = result.games
-    let fallbackUsed = result.fallback
-
-    if (gamesData.length === 0 && stores.length > 0) {
-      const paramsNoStore = new URLSearchParams(searchParams)
-      paramsNoStore.delete("stores")
-      const retry = await fetchAndCache(keyFromObj(paramsNoStore), { ...apiParams, stores: undefined })
-      gamesData = retry.games
-      fallbackUsed = fallbackUsed || retry.fallback
-    }
-
-    const activeStores = gamesData.length === 0 ? [] : stores
-
-    const filteredGames = filterGames(gamesData, {
+    let filteredGames = filterGames(games, {
       platforms,
-      stores: activeStores,
+      stores: storeFilterActive ? stores : [],
       genres,
       maxPrice: maxPrice ? Math.min(Number.parseFloat(maxPrice), 125) : undefined,
       freeToPlay,
@@ -244,75 +175,75 @@ export async function GET(req: NextRequest) {
       minRating: 3.0,
     })
 
-    const headers = {
-      "Cache-Control": "s-maxage=300, stale-while-revalidate=600",
-      "x-cache": source,
+    if (filteredGames.length === 0 && freeToPlay) {
+      const retryParams = { ...apiParams }
+      delete retryParams.genres
+      delete retryParams.maxPrice
+      let retryGames = await fetchRawg(retryParams)
+      if (retryGames.length < 10) {
+        retryGames = [...retryGames, ...fallbackGames]
+      }
+      filteredGames = filterGames(retryGames, {
+        platforms,
+        stores: storeFilterActive ? stores : [],
+        genres: [],
+        maxPrice: undefined,
+        freeToPlay: true,
+        onlyHighRated,
+        minRating: 3.0,
+      })
     }
 
     if (filteredGames.length === 0) {
-      if (freeToPlay) {
-        const f2pAll = filterGames((await searchGamesWithFallbacks({})).games, {
-          freeToPlay: true,
-          stores,
-        })
-        if (f2pAll.length > 0) {
-          const fallback = selectGameWithStrategy(f2pAll, seed, strategy)
-          return NextResponse.json(
-            {
-              game: fallback.game,
-              seed: fallback.usedSeed,
-              strategy: fallback.strategy,
-              total: f2pAll.length,
-            },
-            { headers },
-          )
-        }
-      }
       return NextResponse.json(
-        {
-          error: "Keine Spiele gefunden. Versuche weniger spezifische Filter.",
-          games: [],
-          total: 0,
-          fallback: fallbackUsed,
-        },
-        { headers },
+        { error: "Keine Spiele gefunden. Versuche weniger spezifische Filter.", games: [], total: 0, fallback: false },
+        { headers: { "Cache-Control": "s-maxage=300, stale-while-revalidate=600", "x-cache": "live" } },
       )
     }
 
-    const matchedGames = matchGamesToPreferences(filteredGames, {
-      platforms,
-      stores,
-      genres,
-      maxPrice: maxPrice ? Math.min(Number.parseFloat(maxPrice), 125) : undefined,
-      freeToPlay,
-      onlyHighRated,
-    })
+    await enrichSteamIds(filteredGames)
 
-    const selection = selectGameWithStrategy(matchedGames, seed, strategy)
-
-    const body: any = {
-      game: selection.game,
-      seed: selection.usedSeed,
-      strategy: selection.strategy,
-      total: filteredGames.length,
-      fallback: fallbackUsed,
+    memoryCache.set(cacheKey, { games: filteredGames, fallback: false })
+    if (redis) {
+      redis.set(cacheKey, JSON.stringify({ games: filteredGames, fallback: false }), "EX", 900).catch(() => {})
     }
 
-    if (getAlternatives && selection.game) {
-      const alternatives = generateAlternatives(matchedGames, selection.game, seed, 3)
-      body.alternatives = alternatives
-    }
-
-    return NextResponse.json(body, { headers })
+    return NextResponse.json(
+      { games: filteredGames, total: filteredGames.length, fallback: false },
+      { headers: { "Cache-Control": "s-maxage=300, stale-while-revalidate=600", "x-cache": "live" } },
+    )
   } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+
+    if (message.includes("401") || !process.env.RAWG_KEY) {
+      const games = [...(fallbackGames as any[])]
+      memoryCache.set(cacheKey, { games, fallback: true })
+      if (redis) {
+        redis.set(cacheKey, JSON.stringify({ games, fallback: true }), "EX", 900).catch(() => {})
+      }
+      return NextResponse.json(
+        { games, total: games.length, fallback: true },
+        { headers: { "Cache-Control": "s-maxage=300, stale-while-revalidate=600", "x-cache": "fallback" } },
+      )
+    }
+
+    let cached = memoryCache.get(cacheKey)
+    if (!cached && redis) {
+      const redisValue = await redis.get(cacheKey)
+      if (redisValue) cached = JSON.parse(redisValue)
+    }
+    if (cached) {
+      return NextResponse.json(
+        { games: cached.games, total: cached.games.length, fallback: cached.fallback },
+        { headers: { "Cache-Control": "s-maxage=300, stale-while-revalidate=600", "x-cache": "cache" } },
+      )
+    }
+
     console.error("Games API error:", error)
     return NextResponse.json(
-      {
-        error: "Fehler beim Laden der Spiele. Bitte versuche es später erneut.",
-        games: [],
-        total: 0,
-      },
-      { status: 500, headers: { "x-cache": source } },
+      { error: "Fehler beim Laden der Spiele. Bitte versuche es später erneut.", games: [], total: 0 },
+      { status: 500, headers: { "x-cache": "error" } },
     )
   }
 }
+

--- a/lib/api/rawg.ts
+++ b/lib/api/rawg.ts
@@ -81,3 +81,27 @@ export async function getGameDetails(id: number): Promise<RAWGGame> {
     throw error
   }
 }
+
+export async function getGameStores(
+  id: number,
+): Promise<Array<{ store: { id: number; name: string; slug: string }; url?: string }>> {
+  if (!RAWG_API_KEY) {
+    throw new Error(API_KEY_MISSING_ERROR)
+  }
+
+  try {
+    const response = await limiter.schedule(() =>
+      fetch(`${BASE_URL}/games/${id}/stores?key=${RAWG_API_KEY}`),
+    )
+
+    if (!response.ok) {
+      throw new Error(`RAWG API error: ${response.status}`)
+    }
+
+    const data = await response.json()
+    return data.results || []
+  } catch (error) {
+    console.error("RAWG API error:", error)
+    throw error
+  }
+}


### PR DESCRIPTION
## Summary
- always query RAWG live with expanded page size and merge fallback results
- retry without store filter or with relaxed F2P filters
- enrich games with Steam app IDs via RAWG stores endpoint

## Testing
- `pnpm lint` *(fails: ESLint configuration prompt)*

------
https://chatgpt.com/codex/tasks/task_e_689ff096deb0832dae42e73ca663b2b5