### PR TITLE
feat: add debug tracing and panel

### DIFF
--- a/app/api/games/route.ts
+++ b/app/api/games/route.ts
@@ -1,9 +1,10 @@
 import { type NextRequest, NextResponse } from "next/server"
-import { searchGames, getGameStores } from "@/lib/api/rawg"
+import { getGameStores } from "@/lib/api/rawg"
 import { LRUCache } from "lru-cache"
-import { getRawgPlatformIds, getRawgStoreIds, getRawgGenreIds } from "@/lib/mapping"
+import { validateAndMapParams } from "@/lib/mapping"
 import { isPriceInRange } from "@/lib/price"
 import fallbackGames from "@/data/games-fallback.json"
+import crypto from "crypto"
 
 const memoryCache = new LRUCache<string, { games: any[]; fallback: boolean }>({
   max: 100,
@@ -23,22 +24,36 @@ function keyFromObj(searchParams: URLSearchParams) {
   return JSON.stringify(obj)
 }
 
-async function fetchRawg(params: any) {
-  const response = await searchGames({
-    ...params,
-    page_size: 40,
-    ordering: "-rating,-metacritic",
-    page: 1,
+async function fetchRawg(params: any, rid: string, trace: (p: string, e?: any) => void) {
+  const firstParams = { ...params, page_size: 40, ordering: "-rating,-metacritic", page: 1 }
+  const url1 = `https://api.rawg.io/api/games?${new URLSearchParams({
+    key: process.env.RAWG_KEY || "",
+    ...firstParams,
+  })}`
+  trace(`[${rid}] RAWG request`, { url: url1, page: 1, page_size: 40, filters: params })
+  const res1 = await fetch(url1)
+  const data1 = await res1.json().catch(() => ({}))
+  trace(`[${rid}] RAWG response`, {
+    status: res1.status,
+    count: data1?.count,
+    results: data1?.results?.length,
   })
-  let games = response.results || []
+  let games = data1.results || []
   if (games.length < 10) {
-    const second = await searchGames({
-      ...params,
-      page_size: 40,
-      ordering: "-rating,-metacritic",
-      page: 2,
+    const secondParams = { ...params, page_size: 40, ordering: "-rating,-metacritic", page: 2 }
+    const url2 = `https://api.rawg.io/api/games?${new URLSearchParams({
+      key: process.env.RAWG_KEY || "",
+      ...secondParams,
+    })}`
+    trace(`[${rid}] RAWG request`, { url: url2, page: 2, page_size: 40, filters: params })
+    const res2 = await fetch(url2)
+    const data2 = await res2.json().catch(() => ({}))
+    trace(`[${rid}] RAWG response`, {
+      status: res2.status,
+      count: data2?.count,
+      results: data2?.results?.length,
     })
-    games = [...games, ...(second.results || [])]
+    games = [...games, ...(data2.results || [])]
   }
   return games
 }
@@ -103,7 +118,7 @@ function filterGames(
   })
 }
 
-async function enrichSteamIds(games: any[]) {
+async function enrichSteamIds(games: any[], rid: string, trace: (p: string, e?: any) => void) {
   await Promise.all(
     games.map(async (g) => {
       const steamStore = g.stores?.find((s: any) => s.store?.slug === "steam")
@@ -112,16 +127,20 @@ async function enrichSteamIds(games: any[]) {
         if (match) {
           g.steamAppId = Number(match[1])
         } else {
+          trace(`[${rid}] steam resolve`, { id: g.id })
           try {
             const details = await getGameStores(g.id)
             const steam = details.find((s: any) => s.store?.slug === "steam")
             if (steam?.url) {
+              trace(`[${rid}] steam hit`, { id: g.id })
               steamStore.url = steam.url
               const m = steam.url.match(/\/app\/(\d+)/)
               if (m) g.steamAppId = Number(m[1])
+            } else {
+              trace(`[${rid}] steam miss`, { id: g.id })
             }
           } catch {
-            // ignore
+            trace(`[${rid}] steam fail`, { id: g.id })
           }
         }
       }
@@ -130,66 +149,65 @@ async function enrichSteamIds(games: any[]) {
 }
 
 export async function GET(req: NextRequest) {
-  const searchParams = req.nextUrl.searchParams
-  const platforms = searchParams.get("platforms")?.split(",") || []
-  const stores = searchParams.get("stores")?.split(",") || []
-  const genres = searchParams.get("genres")?.split(",") || []
-  const maxPrice = searchParams.get("maxPrice")
-  const freeToPlay = searchParams.get("freeToPlay") === "true"
-  const onlyHighRated = searchParams.get("onlyHighRated") === "true"
-  const startYear = searchParams.get("startYear")
-  const endYear = searchParams.get("endYear")
+  const T0 = Date.now()
+  const trace = (prefix: string, extra?: any) =>
+    console.log(`[TRACE] ${prefix} t+${Date.now() - T0}ms`, extra ?? "")
+  const rid = crypto.randomUUID()
 
-  const cacheKey = keyFromObj(searchParams)
+  trace(`[${rid}] RAWG_KEY ${process.env.RAWG_KEY ? "present" : "MISSING"}`)
+
+  const q = Object.fromEntries(req.nextUrl.searchParams.entries())
+  trace(`[${rid}] IN params`, q)
+  const { api, filters } = validateAndMapParams(q)
+  trace(`[${rid}] map`, {
+    platforms: api.platforms,
+    stores: api.stores,
+    genres: api.genres,
+    dates: api.dates,
+    priceMax: api.priceMax,
+  })
+
+  const cacheKey = keyFromObj(req.nextUrl.searchParams)
 
   try {
-    const apiParams: any = {}
-    if (platforms.length > 0) apiParams.platforms = getRawgPlatformIds(platforms as any)
-    if (stores.length > 0) apiParams.stores = getRawgStoreIds(stores as any)
-    if (genres.length > 0) apiParams.genres = getRawgGenreIds(genres as any)
-    if (startYear && endYear) apiParams.dates = `${startYear}-01-01,${endYear}-12-31`
-    if (freeToPlay) apiParams.tags = "free-to-play"
-
-    let storeFilterActive = true
-    let games = await fetchRawg(apiParams)
+    let storeFilterActive = Boolean(api.stores)
+    let games = await fetchRawg(api, rid, trace)
+    if (games.length === 0 && api.stores) {
+      trace(`[${rid}] retry without store filter`)
+      const paramsNoStore = { ...api }
+      delete paramsNoStore.stores
+      games = await fetchRawg(paramsNoStore, rid, trace)
+      storeFilterActive = false
+    }
     if (games.length < 10) {
       games = [...games, ...fallbackGames]
     }
-    if (games.length === 0 && stores.length > 0) {
-      const paramsNoStore = { ...apiParams }
-      delete paramsNoStore.stores
-      games = await fetchRawg(paramsNoStore)
-      if (games.length < 10) {
-        games = [...games, ...fallbackGames]
-      }
-      storeFilterActive = false
-    }
 
     let filteredGames = filterGames(games, {
-      platforms,
-      stores: storeFilterActive ? stores : [],
-      genres,
-      maxPrice: maxPrice ? Math.min(Number.parseFloat(maxPrice), 125) : undefined,
-      freeToPlay,
-      onlyHighRated,
+      platforms: filters.platforms,
+      stores: storeFilterActive ? filters.stores : [],
+      genres: filters.genres,
+      maxPrice: filters.priceMax,
+      freeToPlay: q.freeToPlay === "true",
+      onlyHighRated: q.onlyHighRated === "true",
       minRating: 3.0,
     })
 
-    if (filteredGames.length === 0 && freeToPlay) {
-      const retryParams = { ...apiParams }
+    if (filteredGames.length === 0 && q.freeToPlay === "true") {
+      const retryParams = { ...api }
       delete retryParams.genres
-      delete retryParams.maxPrice
-      let retryGames = await fetchRawg(retryParams)
+      delete retryParams.priceMax
+      let retryGames = await fetchRawg(retryParams, rid, trace)
       if (retryGames.length < 10) {
         retryGames = [...retryGames, ...fallbackGames]
       }
       filteredGames = filterGames(retryGames, {
-        platforms,
-        stores: storeFilterActive ? stores : [],
+        platforms: filters.platforms,
+        stores: storeFilterActive ? filters.stores : [],
         genres: [],
         maxPrice: undefined,
         freeToPlay: true,
-        onlyHighRated,
+        onlyHighRated: q.onlyHighRated === "true",
         minRating: 3.0,
       })
     }
@@ -197,11 +215,11 @@ export async function GET(req: NextRequest) {
     if (filteredGames.length === 0) {
       return NextResponse.json(
         { error: "Keine Spiele gefunden. Versuche weniger spezifische Filter.", games: [], total: 0, fallback: false },
-        { headers: { "Cache-Control": "s-maxage=300, stale-while-revalidate=600", "x-cache": "live" } },
+        { headers: { "x-trace-id": rid } },
       )
     }
 
-    await enrichSteamIds(filteredGames)
+    await enrichSteamIds(filteredGames, rid, trace)
 
     memoryCache.set(cacheKey, { games: filteredGames, fallback: false })
     if (redis) {
@@ -210,7 +228,13 @@ export async function GET(req: NextRequest) {
 
     return NextResponse.json(
       { games: filteredGames, total: filteredGames.length, fallback: false },
-      { headers: { "Cache-Control": "s-maxage=300, stale-while-revalidate=600", "x-cache": "live" } },
+      {
+        headers: {
+          "Cache-Control": "s-maxage=300, stale-while-revalidate=600",
+          "x-cache": "live",
+          "x-trace-id": rid,
+        },
+      },
     )
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error)
@@ -223,7 +247,13 @@ export async function GET(req: NextRequest) {
       }
       return NextResponse.json(
         { games, total: games.length, fallback: true },
-        { headers: { "Cache-Control": "s-maxage=300, stale-while-revalidate=600", "x-cache": "fallback" } },
+        {
+          headers: {
+            "Cache-Control": "s-maxage=300, stale-while-revalidate=600",
+            "x-cache": "fallback",
+            "x-trace-id": rid,
+          },
+        },
       )
     }
 
@@ -235,14 +265,20 @@ export async function GET(req: NextRequest) {
     if (cached) {
       return NextResponse.json(
         { games: cached.games, total: cached.games.length, fallback: cached.fallback },
-        { headers: { "Cache-Control": "s-maxage=300, stale-while-revalidate=600", "x-cache": "cache" } },
+        {
+          headers: {
+            "Cache-Control": "s-maxage=300, stale-while-revalidate=600",
+            "x-cache": "cache",
+            "x-trace-id": rid,
+          },
+        },
       )
     }
 
     console.error("Games API error:", error)
     return NextResponse.json(
       { error: "Fehler beim Laden der Spiele. Bitte versuche es später erneut.", games: [], total: 0 },
-      { status: 500, headers: { "x-cache": "error" } },
+      { status: 500, headers: { "x-cache": "error", "x-trace-id": rid } },
     )
   }
 }

--- a/app/api/health/route.ts
+++ b/app/api/health/route.ts
@@ -1,0 +1,32 @@
+import { NextResponse } from "next/server"
+import crypto from "crypto"
+
+export async function GET() {
+  const T0 = Date.now()
+  const trace = (prefix: string, extra?: any) =>
+    console.log(`[TRACE] [health] ${prefix} t+${Date.now() - T0}ms`, extra ?? "")
+  const rid = crypto.randomUUID()
+  const rawgKeyPresent = Boolean(process.env.RAWG_KEY)
+  trace(`[${rid}] RAWG_KEY ${rawgKeyPresent ? "present" : "MISSING"}`)
+  let status = 0
+  let timeMs = 0
+  try {
+    const url = `https://api.rawg.io/api/games?page_size=1&key=${process.env.RAWG_KEY}`
+    trace(`[${rid}] RAWG request`, { url })
+    const t = Date.now()
+    const res = await fetch(url)
+    timeMs = Date.now() - t
+    status = res.status
+    trace(`[${rid}] RAWG response`, { status, timeMs })
+    return NextResponse.json(
+      { ok: res.ok, rawgKey: rawgKeyPresent, status, timeMs },
+      { status: res.ok ? 200 : 500 },
+    )
+  } catch (e) {
+    trace(`[${rid}] RAWG error`, { message: (e as Error).message })
+    return NextResponse.json(
+      { ok: false, rawgKey: rawgKeyPresent, status, timeMs },
+      { status: 500 },
+    )
+  }
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -5,6 +5,7 @@ import { GeistMono } from "geist/font/mono"
 import { Header } from "@/components/Header"
 import { CookieConsent } from "@/components/CookieConsent"
 import { Toaster } from "@/components/ui/toaster"
+import { DebugProvider, DebugPanel } from "@/components/DebugPanel"
 import { cookies } from "next/headers"
 import "./globals.css"
 
@@ -45,10 +46,13 @@ export default async function RootLayout({
         <link rel="alternate" hrefLang="de" href="/" />
       </head>
       <body className="min-h-screen bg-background font-sans antialiased">
-        <Header />
-        <main role="main">{children}</main>
-        <CookieConsent />
-        <Toaster />
+        <DebugProvider>
+          <Header />
+          <main role="main">{children}</main>
+          <CookieConsent />
+          <Toaster />
+          <DebugPanel />
+        </DebugProvider>
       </body>
     </html>
   )

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -14,12 +14,14 @@ import { useToast } from "@/hooks/use-toast"
 import { useLanguage } from "@/hooks/useLanguage"
 import { decodeUrlState, createPermalink } from "@/lib/url-state"
 import { generateSeed } from "@/lib/random"
+import { useDebug } from "@/components/DebugPanel"
 
 export default function HomePage() {
   const searchParams = useSearchParams()
   const router = useRouter()
   const { toast } = useToast()
   const { t, isLoading: isLangLoading } = useLanguage()
+  const { setVisible } = useDebug()
 
   const [currentGame, setCurrentGame] = useState<Game | null>(null)
   const [currentSeed, setCurrentSeed] = useState<number | null>(null)
@@ -329,7 +331,15 @@ export default function HomePage() {
                 exit={{ opacity: 0, scale: 0.95 }}
                 transition={{ duration: 0.3 }}
               >
-                <ErrorState message={error} onRetry={handleRetry} />
+                <ErrorState
+                  message={error}
+                  onRetry={handleRetry}
+                  onDebug={
+                    error === t("errors.noGames")
+                      ? () => setVisible(true)
+                      : undefined
+                  }
+                />
               </motion.div>
             ) : currentGame ? (
               <GameCard

--- a/components/DebugPanel.tsx
+++ b/components/DebugPanel.tsx
@@ -1,0 +1,83 @@
+"use client"
+
+import { createContext, useContext, useState } from "react"
+import { useSearchParams } from "next/navigation"
+
+export interface DebugInfo {
+  filters?: any
+  requestUrl?: string
+  traceId?: string
+  resultCount?: number
+  fallback?: boolean
+  cacheHit?: string | null
+  error?: string | null
+}
+
+interface DebugContextType {
+  info: DebugInfo
+  setInfo: (d: Partial<DebugInfo>) => void
+  visible: boolean
+  setVisible: (v: boolean) => void
+}
+
+const DebugContext = createContext<DebugContextType | null>(null)
+
+export function DebugProvider({ children }: { children: React.ReactNode }) {
+  const [info, setInfoState] = useState<DebugInfo>({})
+  const [visible, setVisible] = useState(false)
+  const setInfo = (d: Partial<DebugInfo>) =>
+    setInfoState((prev) => ({ ...prev, ...d }))
+  return (
+    <DebugContext.Provider value={{ info, setInfo, visible, setVisible }}>
+      {children}
+    </DebugContext.Provider>
+  )
+}
+
+export function useDebug() {
+  const ctx = useContext(DebugContext)
+  if (!ctx) throw new Error("useDebug must be used within DebugProvider")
+  return ctx
+}
+
+export function DebugPanel() {
+  const { info, visible, setVisible } = useDebug()
+  const search = useSearchParams()
+  const show =
+    visible && (process.env.NODE_ENV !== "production" || search.get("debug") === "1")
+  if (!show) return null
+  return (
+    <div className="fixed bottom-4 right-4 bg-black text-white p-4 text-xs max-w-sm rounded z-50 space-y-2">
+      <button
+        className="absolute top-1 right-1 text-white"
+        onClick={() => setVisible(false)}
+      >
+        ×
+      </button>
+      <div>
+        <strong>Filters:</strong>
+        <pre className="whitespace-pre-wrap">{JSON.stringify(info.filters, null, 2)}</pre>
+      </div>
+      <div>
+        <strong>Request:</strong> {info.requestUrl}
+      </div>
+      <div>
+        <strong>x-trace-id:</strong> {info.traceId}
+      </div>
+      <div>
+        <strong>Result count:</strong> {info.resultCount}
+      </div>
+      <div>
+        <strong>Fallback:</strong> {String(info.fallback)}
+      </div>
+      <div>
+        <strong>Cache:</strong> {info.cacheHit ?? ""}
+      </div>
+      {info.error && (
+        <div>
+          <strong>Error:</strong> {info.error}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/components/ErrorState.tsx
+++ b/components/ErrorState.tsx
@@ -8,9 +8,10 @@ import { useLanguage } from "@/hooks/useLanguage"
 interface ErrorStateProps {
   message?: string
   onRetry?: () => void
+  onDebug?: () => void
 }
 
-export function ErrorState({ message, onRetry }: ErrorStateProps) {
+export function ErrorState({ message, onRetry, onDebug }: ErrorStateProps) {
   const { t } = useLanguage()
 
   return (
@@ -25,6 +26,11 @@ export function ErrorState({ message, onRetry }: ErrorStateProps) {
           <Button onClick={onRetry} variant="outline">
             <RefreshCw className="h-4 w-4 mr-2" />
             {t("errors.retry")}
+          </Button>
+        )}
+        {onDebug && (
+          <Button onClick={onDebug} variant="outline" className="mt-4">
+            Debug öffnen
           </Button>
         )}
       </CardContent>

--- a/components/FilterBar.tsx
+++ b/components/FilterBar.tsx
@@ -15,6 +15,7 @@ import { Gamepad2, Shuffle, Star, Sparkles } from "lucide-react"
 import { generateSeed } from "@/lib/random"
 import { useLanguage } from "@/hooks/useLanguage"
 import type { Game } from "./GameCard"
+import { useDebug } from "@/components/DebugPanel"
 
 export interface FilterState {
   platforms: string[]
@@ -36,6 +37,7 @@ interface FilterBarProps {
 
 export function FilterBar({ initialFilters, onFiltersChange, onGameFound, onError, onLoading }: FilterBarProps) {
   const { t } = useLanguage()
+  const { setInfo, setVisible } = useDebug()
 
   const [filters, setFilters] = useState<FilterState>({
     platforms: [],
@@ -101,7 +103,15 @@ export function FilterBar({ initialFilters, onFiltersChange, onGameFound, onErro
       params.append("seed", seed.toString())
       params.append("strategy", "balanced")
 
-      const response = await fetch(`/api/games?${params}`)
+      const url = `/api/games?${params}`
+      console.log("[DEBUG] fetch", url)
+      setInfo({
+        filters,
+        requestUrl: url,
+      })
+      const response = await fetch(url)
+      const traceId = response.headers.get("x-trace-id") || undefined
+      const cacheHit = response.headers.get("x-cache")
 
       if (!response.ok) {
         throw new Error(`API Error: ${response.status}`)
@@ -109,17 +119,35 @@ export function FilterBar({ initialFilters, onFiltersChange, onGameFound, onErro
 
       const data = await response.json()
 
-        if (data.error) {
-          onError?.(data.error)
-          return
-        }
+      setInfo({
+        traceId,
+        cacheHit,
+        resultCount: data.games ? data.games.length : data.game ? 1 : 0,
+        fallback: data.fallback,
+        error: data.error,
+      })
 
-        if (!data.game) {
-          onError?.(t("errors.noGames"))
-          return
-        }
+      if (data.games && data.games.length === 0) {
+        console.warn("[WARN] empty results", {
+          params: Object.fromEntries(params.entries()),
+          traceId,
+        })
+        setVisible(true)
+        onError?.(t("errors.noGames"))
+        return
+      }
 
-        onGameFound?.(data.game, seed, data.strategy)
+      if (data.error) {
+        onError?.(data.error)
+        return
+      }
+
+      if (!data.game) {
+        onError?.(t("errors.noGames"))
+        return
+      }
+
+      onGameFound?.(data.game, seed, data.strategy)
     } catch (error) {
       console.error("Game search error:", error)
       onError?.(error instanceof Error ? error.message : t("errors.apiError"))

--- a/components/GameCard.tsx
+++ b/components/GameCard.tsx
@@ -44,6 +44,10 @@ export function GameCard({ game, seed, strategy, onReroll, onAlternative, onShar
   const [isSharing, setIsSharing] = useState(false)
   const [imageLoaded, setImageLoaded] = useState(false)
 
+  if (!game.background_image) {
+    console.warn("[IMG] missing", { id: game.id, title: game.name })
+  }
+
   const formatPrice = (price?: number, currency = "EUR") => {
     if (price === undefined || price === null) {
       return t("game.price.unavailable")
@@ -89,7 +93,18 @@ export function GameCard({ game, seed, strategy, onReroll, onAlternative, onShar
     (s.store.slug || s.store.name.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-|-$|/g, "")) as StoreSlug
 
   const openStore = (slug?: StoreSlug) => {
-    const url = buildStoreLink(game.name, game.stores as any, slug, game.steamAppId)
+    const { url, usedFallback } = buildStoreLink(
+      game.name,
+      game.stores as any,
+      slug,
+      game.steamAppId,
+    )
+    console.log("[LINK]", {
+      preferredStore: slug,
+      chosenUrl: url,
+      usedFallback,
+      steamAppId: game.steamAppId,
+    })
     window.open(url, "_blank", "noopener,noreferrer")
   }
 

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -5,9 +5,12 @@ import { useLanguage } from "@/hooks/useLanguage"
 import { Gamepad2 } from "lucide-react"
 import { ThemeToggle } from "./ThemeToggle"
 import { LanguageSwitcher } from "./LanguageSwitcher"
+import { Button } from "@/components/ui/button"
+import { useDebug } from "@/components/DebugPanel"
 
 export function Header() {
   const { t, isLoading } = useLanguage()
+  const { visible, setVisible } = useDebug()
 
   if (isLoading) {
     return null
@@ -53,6 +56,9 @@ export function Header() {
           >
             <LanguageSwitcher />
             <ThemeToggle />
+            <Button variant="outline" size="sm" onClick={() => setVisible(!visible)}>
+              Debug
+            </Button>
           </motion.div>
         </div>
       </div>

--- a/lib/mapping.ts
+++ b/lib/mapping.ts
@@ -53,3 +53,100 @@ export function getRawgStoreIds(stores: Store[]): string {
 export function getRawgGenreIds(genres: Genre[]): string {
   return genres.map((genre) => GENRE_MAPPING[genre].rawg).join(",")
 }
+
+export function validateAndMapParams(q: Record<string, any>) {
+  const platformMap: Record<string, string> = {
+    PC: "4",
+    "Xbox One": "11",
+    "Xbox Series X|S": "186",
+    "PS4": "18",
+    "PS5": "187",
+  }
+
+  const allowedStores = [
+    "steam",
+    "epic-games",
+    "gog",
+    "playstation-store",
+    "microsoft-store",
+    "ea-app",
+    "ubisoft-store",
+    "nintendo",
+  ]
+
+  const genreMap: Record<string, string> = {}
+  Object.entries(GENRE_MAPPING).forEach(([name, { rawg }]) => {
+    genreMap[name.toLowerCase()] = rawg
+  })
+
+  const api: Record<string, any> = {}
+  const filters: Record<string, any> = {
+    platforms: [] as string[],
+    stores: [] as string[],
+    genres: [] as string[],
+    priceMax: undefined as number | undefined,
+    dates: undefined as string | undefined,
+  }
+
+  if (q.platforms) {
+    const vals = String(q.platforms).split(",")
+    const ids: string[] = []
+    vals.forEach((p) => {
+      const id = platformMap[p]
+      if (id) {
+        ids.push(id)
+        filters.platforms.push(p)
+      } else {
+        console.warn("[WARN] invalid platform", p)
+      }
+    })
+    if (ids.length > 0) api.platforms = ids.join(",")
+  }
+
+  if (q.stores) {
+    const vals = String(q.stores).split(",")
+    const valid = vals.filter((s) => {
+      const ok = allowedStores.includes(s)
+      if (!ok) console.warn("[WARN] invalid store", s)
+      return ok
+    })
+    if (valid.length > 0) {
+      api.stores = valid.join(",")
+      filters.stores = valid
+    }
+  }
+
+  if (q.genres) {
+    const vals = String(q.genres).split(",")
+    const ids: string[] = []
+    vals.forEach((g) => {
+      const id = genreMap[g.toLowerCase()]
+      if (id) {
+        ids.push(id)
+        filters.genres.push(g)
+      } else {
+        console.warn("[WARN] invalid genre", g)
+      }
+    })
+    if (ids.length > 0) api.genres = ids.join(",")
+  }
+
+  if (q.startYear && q.endYear) {
+    filters.dates = `${q.startYear}-01-01,${q.endYear}-12-31`
+    api.dates = filters.dates
+  }
+
+  if (q.maxPrice) {
+    const price = Math.min(Number.parseFloat(q.maxPrice), 125)
+    if (!Number.isNaN(price)) {
+      filters.priceMax = price
+      api.priceMax = price
+    }
+  }
+
+  if (q.freeToPlay === "true") {
+    api.tags = "free-to-play"
+  }
+
+  return { api, filters }
+}

--- a/lib/storeLinks.ts
+++ b/lib/storeLinks.ts
@@ -6,14 +6,19 @@ export function buildStoreLink(title:string, stores?:GameStore[], preferred?:Sto
   const toSlug = (s:string)=>s.toLowerCase().replace(/[^a-z0-9]+/g,"-").replace(/^-|-$|/g,"")
   const find = (s?:StoreSlug)=>stores?.find(x => normalizeSlug(x.store.slug??toSlug(x.store.name))===s)
   const id = steamAppId || extractSteamAppId(stores)
+  let usedFallback = false
   if ((preferred==="steam" || (!preferred && id)) && id) {
-    return `https://store.steampowered.com/app/${id}/${slugify(title)}/`
+    return { url: `https://store.steampowered.com/app/${id}/${slugify(title)}/`, usedFallback }
   }
   const s = preferred && find(preferred) || stores?.find(x=>x.url)
-  if (s?.url) return s.url
-  if (preferred) return search(preferred,q)
-  if (id) return `https://store.steampowered.com/app/${id}/${slugify(title)}/`
-  return search("steam",q)
+  if (s?.url) return { url: s.url, usedFallback }
+  if (preferred) {
+    usedFallback = true
+    return { url: search(preferred,q), usedFallback }
+  }
+  if (id) return { url: `https://store.steampowered.com/app/${id}/${slugify(title)}/`, usedFallback }
+  usedFallback = true
+  return { url: search("steam",q), usedFallback }
 
   function extractSteamAppId(arr?:GameStore[]){
     const u = arr?.find(x=>normalizeSlug(x.store.slug??toSlug(x.store.name))==="steam")?.url || ""


### PR DESCRIPTION
## Summary
- add request tracing with x-trace-id and RAWG instrumentation
- map & validate query params with warnings
- introduce client-side debug panel and diagnostics

## Testing
- `pnpm lint` *(fails: How would you like to configure ESLint?)*

------
https://chatgpt.com/codex/tasks/task_e_68a203a499a0832d98820417f051201d